### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Friday
 .. .. image:: https://img.shields.io/pypi/v/Friday.svg
 ..        :target: https://pypi.python.org/pypi/Friday
 .. This project has not yet been uploaded to PyPI when it has this will be updated.
-
+[![Run on Repl.it](https://repl.it/badge/github/Zenohm/Friday)](https://repl.it/github/Zenohm/Friday)
 .. image:: https://img.shields.io/travis/Zenohm/Friday.svg
         :target: https://travis-ci.org/Zenohm/Friday
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).